### PR TITLE
Add diff-cleaner: pre-commit hook for cleaner git diffs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "files.trimTrailingWhitespace": true
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,5 +15,5 @@ require('./build-scripts/build.js');
 require('./build-scripts/develop.js');
 require('./build-scripts/test.js');
 require('./build-scripts/bundle.js');
-require('./diff-cleaner/precommit.js');
-require('./diff-cleaner/trim.js');
+require('diff-cleaner/precommit.js');
+require('diff-cleaner/trim.js');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ Broken into five types of tasks:
 - Build Tasks: Used to create a working instance
 - Development Tasks: Used to work inside your development environment
 - Test Tasks: Used to test code
+- Diff Tasks: Ensure clean diffs on pre-commit
 
 */
 require('./build-scripts/install.js');
@@ -14,3 +15,5 @@ require('./build-scripts/build.js');
 require('./build-scripts/develop.js');
 require('./build-scripts/test.js');
 require('./build-scripts/bundle.js');
+require('./diff-cleaner/precommit.js');
+require('./diff-cleaner/trim.js');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "deploy": "gulp deploy",
     "docker": "node build-scripts/docker.js",
     "test": "gulp test",
+    "precommit": "gulp precommit",
+    "trim": "gulp trim",
     "start": "node dist/server/start.js"
   },
   "main": "dist/server/start.js",
@@ -62,6 +64,7 @@
   },
   "devDependencies": {
     "commander": "^2.9.0",
+    "diff-cleaner": "^2.0.0",
     "glob": "^7.0.0",
     "gulp": "^3.9.1",
     "gulp-add-src": "^0.2.0",
@@ -72,6 +75,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-tslint": "^4.3.1",
     "gulp-typescript": "^2.11.0",
+    "husky": "^0.11.5",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^0.2.3",


### PR DESCRIPTION
Changes:
- git pre-commit hook which checks for trailing whitespace and EOF newline, failing the commit as-necessary with a message to use `npm run trim`
- `npm run trim` which cleans all files
- `.vscode` rule which automatically strips trailing whitespace

Notes:
- This PR contains just the installation of `diff-cleaner`
- See #172 for the application of this PR's changes
- See [diff-cleaner](https://www.npmjs.com/package/diff-cleaner) for the utility I wrote to facilitate the pre-commit hook and trim command
- Need to sync with Bobby about where/if to relocate `diff-cleaner`